### PR TITLE
remove: fix retry logic

### DIFF
--- a/LockFreeSortedList.h
+++ b/LockFreeSortedList.h
@@ -208,6 +208,7 @@ public:
         if (!p->next_ptr.compare_exchange_strong(n,n->next_ptr)) // Item changed
         {
           p = head.load(); // start again
+          continue;
         } else {
           found = true;
           m_size.fetch_sub(1);


### PR DESCRIPTION
The original logic properly identifies when the node to be removed has changed, and resets `p` so it points to `head` again. However, it misses a call to `continue` to jump back to the beginning of the loop. Failing to do so causes `p` to be set to a different value once again before going back to the start of the loop.